### PR TITLE
patch to prevent compilation error, examples now compile using arduino 1...

### DIFF
--- a/libraries/BLE/examples/ble_A_Hello_World_Program/ble_A_Hello_World_Program.ino
+++ b/libraries/BLE/examples/ble_A_Hello_World_Program/ble_A_Hello_World_Program.ino
@@ -84,7 +84,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -174,7 +174,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_HID_keyboard_2_bonds_template/ble_HID_keyboard_2_bonds_template.ino
+++ b/libraries/BLE/examples/ble_HID_keyboard_2_bonds_template/ble_HID_keyboard_2_bonds_template.ino
@@ -71,7 +71,7 @@ The setup() and the loop() functions are the equvivlent of main() .
     static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
 
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 #define BYTES_PER_BOND_IN_HEADER       2
 #define BONDS_MAX                      2
@@ -792,7 +792,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_HID_keyboard_template/ble_HID_keyboard_template.ino
+++ b/libraries/BLE/examples/ble_HID_keyboard_template/ble_HID_keyboard_template.ino
@@ -67,7 +67,7 @@ The setup() and the loop() functions are the equvivlent of main() .
     static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
 
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -702,7 +702,7 @@ void setup(void)
   }
 
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   //Tell the ACI library, the MCU to nRF8001 pin connections

--- a/libraries/BLE/examples/ble_HID_template/ble_HID_template.ino
+++ b/libraries/BLE/examples/ble_HID_template/ble_HID_template.ino
@@ -71,7 +71,7 @@ The setup() and the loop() functions are the equvivlent of main() .
     static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
 
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -627,7 +627,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_HID_template_HID_HRM/ble_HID_template_HID_HRM.ino
+++ b/libraries/BLE/examples/ble_HID_template_HID_HRM/ble_HID_template_HID_HRM.ino
@@ -69,7 +69,7 @@ The setup() and the loop() functions are the equvivlent of
   static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
 
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -614,7 +614,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_bandwidth_test/ble_bandwidth_test.ino
+++ b/libraries/BLE/examples/ble_bandwidth_test/ble_bandwidth_test.ino
@@ -83,7 +83,7 @@ Defining number of packets to send
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -196,7 +196,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_broadcast/ble_broadcast.ino
+++ b/libraries/BLE/examples/ble_broadcast/ble_broadcast.ino
@@ -61,7 +61,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
     #define NUMBER_OF_PIPES 0
     static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -112,7 +112,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_heart_rate_template/ble_heart_rate_template.ino
+++ b/libraries/BLE/examples/ble_heart_rate_template/ble_heart_rate_template.ino
@@ -53,7 +53,7 @@
 Store the nRF8001 setup information generated on the flash of the AVR.
 This reduces the RAM requirements for the nRF8001.
 */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 // an aci_struct that will contain
 // total initial credits
 // current credit
@@ -110,7 +110,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_heart_rate_template_with_battery_service/ble_heart_rate_template_with_battery_service.ino
+++ b/libraries/BLE/examples/ble_heart_rate_template_with_battery_service/ble_heart_rate_template_with_battery_service.ino
@@ -66,7 +66,7 @@
 Store the nRF8001 setup information generated on the flash of the AVR.
 This reduces the RAM requirements for the nRF8001.
 */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // an aci_struct that will contain
 // total initial credits
@@ -255,7 +255,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_heart_rate_template_with_simulated_battery_service/ble_heart_rate_template_with_simulated_battery_service.ino
+++ b/libraries/BLE/examples/ble_heart_rate_template_with_simulated_battery_service/ble_heart_rate_template_with_simulated_battery_service.ino
@@ -59,7 +59,7 @@
 Store the nRF8001 setup information generated on the flash of the AVR.
 This reduces the RAM requirements for the nRF8001.
 */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 // an aci_struct that will contain
 // total initial credits
 // current credit
@@ -200,7 +200,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   //Tell the ACI library, the MCU to nRF8001 pin connections

--- a/libraries/BLE/examples/ble_modify_setup_data/ble_modify_setup_data.ino
+++ b/libraries/BLE/examples/ble_modify_setup_data/ble_modify_setup_data.ino
@@ -85,7 +85,7 @@ However this removes the need to do the setup of the nRF8001 on every reset
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -217,7 +217,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_my_project_template/ble_my_project_template.ino
+++ b/libraries/BLE/examples/ble_my_project_template/ble_my_project_template.ino
@@ -61,7 +61,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
     #define NUMBER_OF_PIPES 0
     static services_pipe_type_mapping_t * services_pipe_type_mapping = NULL;
 #endif
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 //@todo have an aci_struct that will contain
 // total initial credits
@@ -116,7 +116,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_proximity_template/ble_proximity_template.ino
+++ b/libraries/BLE/examples/ble_proximity_template/ble_proximity_template.ino
@@ -83,7 +83,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -650,7 +650,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   //Tell the ACI library, the MCU to nRF8001 pin connections

--- a/libraries/BLE/examples/ble_temperature_template/ble_temperature_template.ino
+++ b/libraries/BLE/examples/ble_temperature_template/ble_temperature_template.ino
@@ -61,7 +61,7 @@
 
 #define TEMPERATURE_NUM_SAMPLES  10
 
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 // aci_struct that will contain
 // total initial credits
 // current credit
@@ -362,7 +362,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_uart_project_template/ble_uart_project_template.ino
+++ b/libraries/BLE/examples/ble_uart_project_template/ble_uart_project_template.ino
@@ -84,7 +84,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 // aci_struct that will contain
 // total initial credits
@@ -175,7 +175,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /*

--- a/libraries/BLE/examples/ble_uart_project_with_dfu_template/ble_uart_project_with_dfu_template.ino
+++ b/libraries/BLE/examples/ble_uart_project_with_dfu_template/ble_uart_project_with_dfu_template.ino
@@ -87,7 +87,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM =
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM =
   SETUP_MESSAGES_CONTENT;
 
 static struct aci_state_t aci_state;
@@ -277,7 +277,7 @@ void setup(void)
     aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
   }
   aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-  aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+  aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
   aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
   /* Tell the ACI library, the MCU to nRF8001 pin connections.


### PR DESCRIPTION
...:1.0.5+dfsg2-2 (which is the version in the ubuntu and debian repositories).

Note: this bug has already been documented in various places:
- https://github.com/RedBearLab/BLEShield/pull/5
- https://redbearlab.zendesk.com/entries/23440476-Getting-Started
- http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&t=38003

find . -name "_.ino" -print | xargs subl
find . -name "_.cpp" -print | xargs subl

find:
static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM

replace:
static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM

find:
aci_state.aci_setup_info.setup_msgs = setup_msgs;

replace:
aci_state.aci_setup_info.setup_msgs = (hal_aci_data_t*)setup_msgs;
