### PR TITLE
Set timing fields of aci_stat for ACI_EVT_CONNECTED in lib_aci_event_get...

### DIFF
--- a/libraries/BLE/lib_aci.cpp
+++ b/libraries/BLE/lib_aci.cpp
@@ -611,6 +611,12 @@ bool lib_aci_event_get(aci_state_t *aci_stat, hal_aci_evt_t *p_aci_evt_data)
                 aci_stat->supervision_timeout = aci_evt->params.timing.conn_rf_timeout;
             break;
 
+        case ACI_EVT_CONNECTED:
+                aci_stat->connection_interval = aci_evt->params.connected.conn_rf_interval;
+                aci_stat->slave_latency       = aci_evt->params.connected.conn_slave_rf_latency;
+                aci_stat->supervision_timeout = aci_evt->params.connected.conn_rf_timeout;
+            break;
+
         default:
             /* Need default case to avoid compiler warnings about missing enum
              * values on some platforms.


### PR DESCRIPTION
Both the ACI_EVT_TIMING and ACI_EVT_CONNECTED events include timing values, but currently they're only copied into the passed in aci_stat structure for ACI_EVT_TIMING.

So the timing calls like lib_aci_get_cx_interval_ms(...) return 0 after the ACI_EVT_CONNECTED is received and only report a proper value if you actively change the timing using lib_aci_change_timing(...) or lib_aci_change_timing_GAP_PPCP().

This small change copies the timing values for ACI_EVT_CONNECTED, just as is currently done for ACI_EVT_TIMING, so that the user can later retrieve the initial timing values received when the connection was established using lib_aci_get_cx_interval_ms(...) etc.
