### PR TITLE
Additional includes needed when library is used outside of .ino file

### DIFF
--- a/libraries/BLE/aci.h
+++ b/libraries/BLE/aci.h
@@ -48,6 +48,9 @@
  *
  */
 
+
+#include <stdint.h>
+
 #ifndef ACI_H__
 #define ACI_H__
 

--- a/libraries/BLE/aci_setup.h
+++ b/libraries/BLE/aci_setup.h
@@ -23,6 +23,8 @@
 #ifndef H_ACI_SETUP
 #define H_ACI_SETUP
 
+#include "lib_aci.h"
+
 #define SETUP_SUCCESS                        0
 #define SETUP_FAIL_COMMAND_QUEUE_NOT_EMPTY   1
 #define SETUP_FAIL_EVENT_QUEUE_NOT_EMPTY     2


### PR DESCRIPTION
To reproduce:
Create a new project with additional .c/.cpp files. Include the BLE library in the project, and copy all those includes to one of the .c files as well. Make calls to the BLE library from that external .c file. Project will fail to compile, complaining of unknown types. These includes get the type definitions in the right place for successful compilation.

There might be a better way to handle this case, but at any rate, this worked for me, and I just thought I'd share.
